### PR TITLE
Update illuminate support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "^5.0",
-        "illuminate/support": "^5.0"
+        "illuminate/support": "5.0.* || 5.1.* || 5.2.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.0",


### PR DESCRIPTION
We don't need to specify the Laravel framework.
