### PR TITLE
Update ArtisanViewServiceProvider.php

### DIFF
--- a/src/ArtisanViewServiceProvider.php
+++ b/src/ArtisanViewServiceProvider.php
@@ -6,7 +6,7 @@ use Illuminate\Support\ServiceProvider;
 
 class ArtisanViewServiceProvider extends ServiceProvider
 {
-     /**
+    /**
      * Indicates if loading of the provider is deferred.
      *
      * @var bool
@@ -32,7 +32,7 @@ class ArtisanViewServiceProvider extends ServiceProvider
     {
         $this->commands([
             Commands\MakeViewCommand::class,
-            Commands\ScrapViewCommand::class
+            Commands\ScrapViewCommand::class,
         ]);
     }
 
@@ -45,7 +45,7 @@ class ArtisanViewServiceProvider extends ServiceProvider
     {
         return [
             Commands\MakeViewCommand::class,
-            Commands\ScrapViewCommand::class
+            Commands\ScrapViewCommand::class,
         ];
     }
 }

--- a/src/ArtisanViewServiceProvider.php
+++ b/src/ArtisanViewServiceProvider.php
@@ -6,6 +6,13 @@ use Illuminate\Support\ServiceProvider;
 
 class ArtisanViewServiceProvider extends ServiceProvider
 {
+     /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
     /**
      * Bootstrap the application services.
      *
@@ -13,18 +20,7 @@ class ArtisanViewServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app['make:view'] = $this->app->share(function () {
-            return new Commands\MakeViewCommand();
-        });
-
-        $this->app['scrap:view'] = $this->app->share(function () {
-            return new Commands\ScrapViewCommand();
-        });
-
-        $this->commands(
-            'make:view',
-            'scrap:view'
-        );
+        //
     }
 
     /**
@@ -34,6 +30,22 @@ class ArtisanViewServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->commands([
+            Commands\MakeViewCommand::class,
+            Commands\ScrapViewCommand::class
+        ]);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [
+            Commands\MakeViewCommand::class,
+            Commands\ScrapViewCommand::class
+        ];
     }
 }


### PR DESCRIPTION
shared & bindShared should be replaceable by call to app->singleton.
But since it's only commands getting registered, 
then making it a deferred ServiceProvider shouldn't be an issue. :)