### PR TITLE
Added generated views with bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ $ php artisan make:view products --resource
 $ php artisan make:view products --resource --verb=index --verb=create --verb=edit
 ```
 
+### Generate views (with bootstrap only)
+```bash
+# Create a resource called 'products' with generated views using bootstrap ui extending layout.php
+$ php artisan make:view products --resource --generate product --ui bootstrap --extends layout.php
+
+# Create and generate edit and index views based on Product model using bootstrap ui extending layout.php
+$ php artisan make:view products --verb=edit --verb=index --generate product --ui bootstrap --extends layout.php
+```
+
 ### Scrapping views
 ```bash
 # Remove the view 'index.blade.php'

--- a/src/CRUD/Generate.php
+++ b/src/CRUD/Generate.php
@@ -1,0 +1,571 @@
+<?php
+
+namespace Sven\ArtisanView\CRUD;
+
+use Exception;
+use Sven\ArtisanView\BlockBuilder;
+use Sven\ArtisanView\Config;
+use Sven\ArtisanView\PathHelper;
+
+class Generate
+{
+    /**
+     * @var Config
+     */
+    private static $config;
+
+    /**
+     * @var ViewType
+     */
+    private static $viewType;
+
+    /**
+     * @param $view string
+     * @param $type ViewType
+     * @param Config $config
+     * @param array $blocks
+     * @param string | null $ui
+     * @return void
+     * @throws Exception
+     */
+    public static function viewType(string $view, ViewType $type, Config $config, array $blocks, string|null $ui): void
+    {
+        self::$config = $config;
+        self::$viewType = $type;
+        if (empty($ui)) {
+            $ui = 'bootstrap';
+        }
+
+        $contents = BlockBuilder::build($blocks);
+
+        switch ($type) {
+            case ViewType::INDEX:
+                self::index($view, $contents, $ui);
+                break;
+            case ViewType::CREATE:
+                self::create($view, $contents, $ui);
+                break;
+            case ViewType::EDIT:
+                self::edit($view, $contents, $ui);
+                break;
+            case ViewType::SHOW:
+                self::show($view, $contents, $ui);
+                break;
+            case ViewType::DELETE:
+                self::delete($view, $contents, $ui);
+                break;
+            default:
+                throw new Exception('Invalid view type');
+        }
+    }
+
+    /**
+     * @param $view string
+     * @param string $contents
+     * @param string $ui
+     * @return void
+     * @throws Exception
+     */
+    private static function index(string $view, string $contents, string $ui): void
+    {
+        // Make path
+        if (empty($path = self::makePath($view))) {
+            return;
+        }
+
+        // Get model dynamically
+        $modelClass = 'App\\Models\\' . ucfirst(self::$config->getGenerate());
+        $model = new $modelClass;
+
+        // Make contents based on UI
+        switch ($ui) {
+            case 'bootstrap':
+                $contents = self::indexBootstrap($model, $contents);
+                break;
+            default:
+                throw new Exception('Invalid UI');
+        }
+
+
+        // Write to file
+        file_put_contents($path, $contents);
+    }
+
+    /**
+     * @param string $name
+     * @return string|null
+     */
+    private static function makePath(string $name): string|null
+    {
+        $path = PathHelper::normalizePath(self::$config->getPath() . DIRECTORY_SEPARATOR . $name);
+        PathHelper::createIntermediateFolders($path);
+
+        if (!is_dir($path)) {
+            mkdir($path, 0777, true);
+        }
+
+        // If path is folder
+        if (!is_file($path)) {
+            $path .= DIRECTORY_SEPARATOR . self::$viewType->value . '.blade.php';
+        }
+
+        if (file_exists($path)) {
+            print("SKIPPING {$path} : already exists\n");
+            return null;
+        }
+
+        return $path;
+    }
+
+    private static function indexBootstrap($model, string $contents): string
+    {
+        $contents .= "@section('content')\n";
+
+        // Make form header
+        $collection = strtolower(self::$config->getGenerate());
+        $ucCollection = ucfirst($collection);
+
+        $contents .= <<<EOT
+<div class="container">
+
+    @foreach(\${$collection}s as \${$collection})
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+
+
+                <div class="card-header">{{ __('$ucCollection') }}</div>
+
+
+                <div class="card-body">
+
+EOT;
+
+        // Get model attributes
+        foreach ($model->getFillable() as $field) {
+            if (in_array($field, $model->getHidden())) {
+                continue;
+            }
+            $ucField = ucfirst($field);
+
+            $contents .= <<<EOT
+                        <div class="row mb-3">
+                            <label for="{$field}" class="col-md-4 col-form-label text-md-end">{{ __('{$ucField}') }}</label>
+
+                            <div class="col-md-6">
+                                <span id="{$field}" class="form-control">{{ old('{$field}', \${$collection}->{$field}) }}</span>
+                            </div>
+                        </div>
+
+
+EOT;
+        }
+
+        $button = ucfirst(self::$viewType->value);
+
+        $contents .= <<< EOT
+                </div>
+           </div>
+      </div>
+  </div>
+  <br>
+                @endforeach
+</div>
+@endsection
+EOT;
+
+        return $contents;
+    }
+
+    /**
+     * @param $view string
+     * @param string $contents
+     * @param string $ui
+     * @return void
+     * @throws Exception
+     */
+    private static function create(string $view, string $contents, string $ui): void
+    {
+        // Make path
+        if (empty($path = self::makePath($view))) {
+            return;
+        }
+
+        // Get model dynamically
+        $modelClass = 'App\\Models\\' . ucfirst(self::$config->getGenerate());
+        $model = new $modelClass;
+
+        // Make contents based on UI
+        switch ($ui) {
+            case 'bootstrap':
+                $contents = self::createBootstrap($model, $contents);
+                break;
+            default:
+                throw new Exception('Invalid UI');
+        }
+
+
+        // Write to file
+        file_put_contents($path, $contents);
+    }
+
+    /**
+     * @param $model
+     * @param string $contents
+     * @return string
+     */
+    private static function createBootstrap($model, string $contents): string
+    {
+        $contents .= "@section('content')\n";
+
+        // Make form header
+        $route = self::getRoute();
+
+        $contents .= <<<EOT
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">{{ __('Create') }}</div>
+
+                <div class="card-body">
+                    <form method="POST" action="{{ route('{$route}') }}">
+                    @csrf
+
+EOT;
+
+        // Get model attributes
+        foreach ($model->getFillable() as $field) {
+            $ucField = ucfirst($field);
+            $type = $field;
+            $contents .= <<<EOT
+                        <div class="row mb-3">
+                            <label for="{$field}" class="col-md-4 col-form-label text-md-end">{{ __('{$ucField}') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="{$field}" type="{$type}" class="form-control @error('{$field}') is-invalid @enderror" name="{$field}" required autocomplete="{$field}" autofocus>
+                            </div>
+                        </div>
+
+EOT;
+        }
+
+        $button = ucfirst(self::$viewType->value);
+
+        $contents .= <<< EOT
+                        <div class="row mb-0">
+                            <div class="col-md-6 offset-md-4">
+                                <button type="submit" class="btn btn-success form-control">
+                                    {{ __('{$button}') }}
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+EOT;
+
+
+        return $contents;
+    }
+
+    /**
+     * @return string
+     */
+    private static function getRoute(): string
+    {
+        return strtolower(self::$config->getGenerate()) . '.' . strtolower(self::$viewType->value);
+    }
+
+    /**
+     * @param $view string
+     * @param string $contents
+     * @param string $ui
+     * @return void
+     * @throws Exception
+     */
+    private static function edit(string $view, string $contents, string $ui): void
+    {
+        // Make path
+        if (empty($path = self::makePath($view))) {
+            return;
+        }
+
+        // Get model dynamically
+        $modelClass = 'App\\Models\\' . ucfirst(self::$config->getGenerate());
+        $model = new $modelClass;
+
+        // Make contents based on UI
+        switch ($ui) {
+            case 'bootstrap':
+                $contents = self::editBootstrap($model, $contents);
+                break;
+            default:
+                throw new Exception('Invalid UI');
+        }
+
+
+        // Write to file
+        file_put_contents($path, $contents);
+    }
+
+    /**
+     * @param $model
+     * @param string $contents
+     * @return string
+     */
+    private static function editBootstrap($model, string $contents): string
+    {
+        $contents .= "@section('content')\n";
+
+        // Make form header
+        $route = self::getRoute();
+        $object = strtolower(self::$config->getGenerate());
+
+        $contents .= <<<EOT
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">{{ __('Edit') }}</div>
+
+                <div class="card-body">
+                    <form method="POST" action="{{ route('{$route}') }}">
+                    @csrf
+
+EOT;
+
+        // Get model attributes
+        foreach ($model->getFillable() as $field) {
+            $ucField = ucfirst($field);
+            $type = $field;
+            if (in_array($field, $model->getHidden())) {
+                $val = '';
+            } else {
+                $val = "\${$object}->{$field}";
+            }
+            $contents .= <<<EOT
+                        <div class="row mb-3">
+                            <label for="{$field}" class="col-md-4 col-form-label text-md-end">{{ __('{$ucField}') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="{$field}" type="{$type}" class="form-control @error('{$field}') is-invalid @enderror" name="{$field}" value="{{ old('{$field}', {$val}) }}" required autocomplete="{$field}" autofocus>
+                            </div>
+                        </div>
+
+EOT;
+        }
+
+        $button = ucfirst(self::$viewType->value);
+
+        $contents .= <<< EOT
+                        <div class="row mb-0">
+                            <div class="col-md-6 offset-md-4">
+                                <button type="submit" class="btn btn-primary form-control">
+                                    {{ __('{$button}') }}
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+EOT;
+
+
+        return $contents;
+    }
+
+    /**
+     * @param $view string
+     * @param string $contents
+     * @param string $ui
+     * @return void
+     * @throws Exception
+     */
+    private static function show(string $view, string $contents, string $ui): void
+    {
+        // Make path
+        if (empty($path = self::makePath($view))) {
+            return;
+        }
+
+        // Get model dynamically
+        $modelClass = 'App\\Models\\' . ucfirst(self::$config->getGenerate());
+        $model = new $modelClass;
+
+        // Make contents based on UI
+        switch ($ui) {
+            case 'bootstrap':
+                $contents = self::showBootstrap($model, $contents);
+                break;
+            default:
+                throw new Exception('Invalid UI');
+        }
+
+
+        // Write to file
+        file_put_contents($path, $contents);
+    }
+
+    /**
+     * @param $model
+     * @param string $contents
+     * @return string
+     */
+    private static function showBootstrap($model, string $contents): string
+    {
+        $contents .= "@section('content')\n";
+
+        // Make form header
+        $contents .= <<<EOT
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">{{ __('Show') }}</div>
+
+                <div class="card-body">
+
+EOT;
+
+        // Get model attributes
+        foreach ($model->getFillable() as $field) {
+            if (in_array($field, $model->getHidden())) {
+                continue;
+            }
+            $ucField = ucfirst($field);
+
+            $contents .= <<<EOT
+                        <div class="row mb-3">
+                            <label for="{$field}" class="col-md-4 col-form-label text-md-end">{{ __('{$ucField}') }}</label>
+
+                            <div class="col-md-6">
+                                <span id="{$field}" class="form-control">{{ old('{$field}', \${$field}) }}</span>
+                            </div>
+                        </div>
+
+EOT;
+        }
+
+        $button = ucfirst(self::$viewType->value);
+
+        $contents .= <<< EOT
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+EOT;
+
+
+        return $contents;
+    }
+
+    /**
+     * @param $view string
+     * @param string $contents
+     * @param string $ui
+     * @return void
+     * @throws Exception
+     */
+    private static function delete(string $view, string $contents, string $ui): void
+    {
+        // Make path
+        if (empty($path = self::makePath($view))) {
+            return;
+        }
+
+        // Get model dynamically
+        $modelClass = 'App\\Models\\' . ucfirst(self::$config->getGenerate());
+        $model = new $modelClass;
+
+        // Make contents based on UI
+        switch ($ui) {
+            case 'bootstrap':
+                $contents = self::deleteBootstrap($model, $contents);
+                break;
+            default:
+                throw new Exception('Invalid UI');
+        }
+
+
+        // Write to file
+        file_put_contents($path, $contents);
+    }
+
+    /**
+     * @param $model
+     * @param string $contents
+     * @return string
+     */
+    private static function deleteBootstrap($model, string $contents): string
+    {
+        $contents .= "@section('content')\n";
+
+        // Make form header
+        $route = self::getRoute();
+
+        $contents .= <<<EOT
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">{{ __('Delete') }}</div>
+
+                <div class="card-body">
+                    <form method="POST" action="{{ route('{$route}') }}">
+                    @csrf
+
+EOT;
+
+        // Get model attributes
+        foreach ($model->getFillable() as $field) {
+            if (in_array($field, $model->getHidden())) {
+                continue;
+            }
+            $ucField = ucfirst($field);
+
+            $contents .= <<<EOT
+                        <div class="row mb-3">
+                            <label for="{$field}" class="col-md-4 col-form-label text-md-end">{{ __('{$ucField}') }}</label>
+
+                            <div class="col-md-6">
+                                <span id="{$field}" class="form-control">{{ old('{$field}', \${$field}) }}</span>
+                            </div>
+                        </div>
+
+EOT;
+        }
+
+        $button = ucfirst(self::$viewType->value);
+
+        $contents .= <<< EOT
+                        <div class="row mb-0">
+                            <div class="col-md-6 offset-md-4">
+                                <button type="submit" class="btn btn-danger form-control">
+                                    {{ __('{$button}') }}
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+EOT;
+
+
+        return $contents;
+    }
+}

--- a/src/CRUD/ViewType.php
+++ b/src/CRUD/ViewType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Sven\ArtisanView\CRUD;
+
+enum ViewType: string
+{
+    case INDEX = 'index';
+    case CREATE = 'create';
+    case EDIT = 'edit';
+    case SHOW = 'show';
+    case DELETE = 'delete';
+    case RESOURCE = 'resource';
+
+    public static function toArray(): array
+    {
+        return [
+            self::INDEX->value,
+            self::CREATE->value,
+            self::EDIT->value,
+            self::SHOW->value,
+            self::DELETE->value
+        ];
+    }
+}

--- a/src/Commands/MakeView.php
+++ b/src/Commands/MakeView.php
@@ -46,7 +46,8 @@ class MakeView extends Command
             ->setName($this->argument('name'))
             ->setExtension($this->option('extension'))
             ->setResource($this->option('resource'))
-            ->setVerbs(...$this->option('verb'));
+            ->setVerbs(...$this->option('verb'))
+            ->setGenerate($this->option('generate'));
     }
 
     private function getPath()
@@ -68,11 +69,13 @@ class MakeView extends Command
         return [
             ['extension', null, InputOption::VALUE_OPTIONAL, 'The extension of the generated view.', 'blade.php'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Whether or not a RESTful resource should be created.'],
-            ['verb', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The HTTP verb(s) to generate views for.', ['index', 'show', 'create', 'edit']],
+            ['verb', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The HTTP verb(s) to generate views for.', ['index', 'show', 'create', 'edit', 'delete']],
             ['section', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'A list of "@section"s to define in the created view(s).'],
             ['extends', null, InputOption::VALUE_OPTIONAL, 'The view to "@extend" from the created view(s).'],
             ['with-yields', 'y', InputOption::VALUE_NONE, 'Whether or not to add all "@yield" sections from extended template (if "--extends" was provided)'],
             ['with-stacks', 's', InputOption::VALUE_NONE, 'Whether or not to add all "@stacks" from extended template as @push (if "--extends" was provided)'],
+            ['generate', 'g', InputOption::VALUE_OPTIONAL, 'Generate CRUD based on model'],
+            ['ui', null, InputOption::VALUE_OPTIONAL, 'Specify the UI framework to use', 'bootstrap']
         ];
     }
 

--- a/src/Commands/ScrapView.php
+++ b/src/Commands/ScrapView.php
@@ -71,7 +71,7 @@ class ScrapView extends Command
             ['force', null, InputOption::VALUE_NONE, 'Don\'t ask for confirmation before scrapping the view.'],
             ['extension', null, InputOption::VALUE_REQUIRED, 'The extension of the view to scrap.', 'blade.php'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Whether or not a RESTful resource should be scrapped.'],
-            ['verb', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The HTTP verb(s) to scrap views for.', ['index', 'show', 'create', 'edit']],
+            ['verb', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The HTTP verb(s) to scrap views for.', ['index', 'show', 'create', 'edit', 'delete']],
         ];
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -24,7 +24,7 @@ class Config
     /**
      * @var array
      */
-    protected $verbs = ['index', 'create', 'edit', 'show'];
+    protected $verbs = ['index', 'create', 'edit', 'show', 'delete'];
 
     /**
      * @var bool
@@ -37,15 +37,14 @@ class Config
     protected $path;
 
     /**
-     * @param  string  $name
-     * @return \Sven\ArtisanView\Config
+     * @var string
      */
-    public function setName($name)
-    {
-        $this->name = $name;
+    protected $generate;
 
-        return $this;
-    }
+    /**
+     * @var string
+     */
+    protected $ui;
 
     /**
      * @return string
@@ -56,16 +55,12 @@ class Config
     }
 
     /**
-     * @param  string  $extension
-     * @return \Sven\ArtisanView\Config
+     * @param string $name
+     * @return Config
      */
-    public function setExtension($extension)
+    public function setName($name)
     {
-        if (!Str::startsWith($extension, '.')) {
-            $extension = ".$extension";
-        }
-
-        $this->extension = $extension;
+        $this->name = $name;
 
         return $this;
     }
@@ -79,12 +74,16 @@ class Config
     }
 
     /**
-     * @param  bool  $resource
-     * @return \Sven\ArtisanView\Config
+     * @param string $extension
+     * @return Config
      */
-    public function setResource($resource)
+    public function setExtension($extension)
     {
-        $this->resource = $resource;
+        if (!Str::startsWith($extension, '.')) {
+            $extension = ".$extension";
+        }
+
+        $this->extension = $extension;
 
         return $this;
     }
@@ -98,12 +97,12 @@ class Config
     }
 
     /**
-     * @param  mixed  ...$verbs
-     * @return \Sven\ArtisanView\Config
+     * @param bool $resource
+     * @return Config
      */
-    public function setVerbs(...$verbs)
+    public function setResource($resource)
     {
-        $this->verbs = $verbs;
+        $this->resource = $resource;
 
         return $this;
     }
@@ -117,6 +116,17 @@ class Config
     }
 
     /**
+     * @param mixed ...$verbs
+     * @return Config
+     */
+    public function setVerbs(...$verbs)
+    {
+        $this->verbs = $verbs;
+
+        return $this;
+    }
+
+    /**
      * @return bool
      */
     public function isForce()
@@ -125,8 +135,8 @@ class Config
     }
 
     /**
-     * @param  bool  $force
-     * @return \Sven\ArtisanView\Config
+     * @param bool $force
+     * @return Config
      */
     public function setForce(bool $force)
     {
@@ -143,6 +153,30 @@ class Config
     public function setPath($path)
     {
         $this->path = $path;
+
+        return $this;
+    }
+
+    public function getGenerate()
+    {
+        return $this->generate;
+    }
+
+    public function setGenerate($generate)
+    {
+        $this->generate = $generate;
+
+        return $this;
+    }
+
+    public function getUi()
+    {
+        return $this->ui;
+    }
+
+    public function setUi($ui)
+    {
+        $this->ui = $ui;
 
         return $this;
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -2,14 +2,59 @@
 
 namespace Sven\ArtisanView;
 
+use Exception;
+use Sven\ArtisanView\Blocks\Block;
+use Sven\ArtisanView\CRUD\Generate;
+use Sven\ArtisanView\CRUD\ViewType;
+
 class Generator extends ViewActor
 {
     /**
-     * @param  \Sven\ArtisanView\BlockStack  $blockStack
+     * @param BlockStack $blockStack
+     * @throws Exception
      */
     public function generate(BlockStack $blockStack)
     {
         $views = $this->getViews();
+
+        if ($this->isGenerated()) {
+            foreach ($views as $view) {
+                $view = explode('.', $view);;
+                if(count($view) > 1) {
+                    $verbs = [$view[1]];
+                } else {
+                    $verbs = $this->config->getVerbs();
+                }
+
+                $view = $view[0];
+
+                foreach($verbs as $verb) {
+                    switch ($verb) {
+                        case 'index':
+                            $type = ViewType::INDEX;
+                            break;
+                        case 'create':
+                            $type = ViewType::CREATE;
+                            break;
+                        case 'edit':
+                            $type = ViewType::EDIT;
+                            break;
+                        case 'show':
+                            $type = ViewType::SHOW;
+                            break;
+                        case 'delete':
+                            $type = ViewType::DELETE;
+                            break;
+                        default:
+                            throw new Exception('Invalid view type');
+                    }
+
+                    Generate::viewType($view, $type, $this->config, $blockStack->all(), $this->config->getUi());
+                }
+            }
+
+            return;
+        }
 
         $this->makeViews(
             $this->getViewNames($views), $blockStack->all()
@@ -17,15 +62,15 @@ class Generator extends ViewActor
     }
 
     /**
-     * @param  array  $names
-     * @param  \Sven\ArtisanView\Blocks\Block[]  $blocks
+     * @param array $names
+     * @param Block[] $blocks
      */
     protected function makeViews(array $names, array $blocks)
     {
         $contents = BlockBuilder::build($blocks);
 
         foreach ($names as $name) {
-            $path = PathHelper::normalizePath($this->config->getPath().DIRECTORY_SEPARATOR.$name);
+            $path = PathHelper::normalizePath($this->config->getPath() . DIRECTORY_SEPARATOR . $name);
             PathHelper::createIntermediateFolders($path);
 
             file_put_contents($path, $contents);

--- a/src/ViewActor.php
+++ b/src/ViewActor.php
@@ -5,15 +5,15 @@ namespace Sven\ArtisanView;
 abstract class ViewActor
 {
     /**
-     * @var \Sven\ArtisanView\Config
+     * @var Config
      */
     protected $config;
 
     /**
      * ViewActor constructor.
      *
-     * @param  \Sven\ArtisanView\Config  $config
-     * @param  string  $path
+     * @param Config $config
+     * @param string $path
      */
     public function __construct(Config $config, $path)
     {
@@ -31,12 +31,12 @@ abstract class ViewActor
         }
 
         return array_map(function ($view) {
-            return $this->config->getName().'.'.$view;
+            return $this->config->getName() . '.' . $view;
         }, $this->config->getVerbs());
     }
 
     /**
-     * @param  array  $names
+     * @param array $names
      * @return array
      */
     protected function getViewNames(array $names)
@@ -44,7 +44,15 @@ abstract class ViewActor
         return array_map(function ($name) {
             $name = str_replace('.', '/', $name);
 
-            return $name.$this->config->getExtension();
+            return $name . $this->config->getExtension();
         }, $names);
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isGenerated(): bool
+    {
+        return !empty($this->config->getGenerate());
     }
 }

--- a/tests/CRUDTest.php
+++ b/tests/CRUDTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Sven\ArtisanView\Tests\CRUD;
+
+use Sven\ArtisanView\Tests\TestCase;
+use Mockery as m;
+
+class CRUDTest extends TestCase
+{
+
+    public function test_it_makes_a_new_view()
+    {
+        $productModel = m::mock('overload:App\Models\Product');
+        $productModel->shouldReceive('getFillable')->andReturn([]);
+        app()->instance('App\Models\Product', $productModel);
+
+        $this->artisan('make:view', [
+            'name' => 'product',
+            '--generate' => 'product',
+            '--ui' => 'bootstrap',
+            '--extends' => 'layouts.app',
+            '--resource' => true,
+        ]);
+
+        $this->assertViewExists('product/index.blade.php');
+        $this->assertViewExists('product/show.blade.php');
+        $this->assertViewExists('product/create.blade.php');
+        $this->assertViewExists('product/delete.blade.php');
+        $this->assertViewExists('product/edit.blade.php');
+
+        $this->artisan('scrap:view', [
+            'name' => 'product',
+            '--resource' => true,
+            '--force' => true,
+        ]);
+
+        $this->assertViewNotExists('product/index.blade.php');
+        $this->assertViewNotExists('product/show.blade.php');
+        $this->assertViewNotExists('product/create.blade.php');
+        $this->assertViewNotExists('product/delete.blade.php');
+        $this->assertViewNotExists('product/edit.blade.php');
+    }
+
+    public function test_it_makes_a_new_view_with_verbs()
+    {
+        $productModel = m::mock('overload:App\Models\Product');
+        $productModel->shouldReceive('getFillable')->andReturn([]);
+        app()->instance('App\Models\Product', $productModel);
+
+        $this->artisan('make:view', [
+            'name' => 'product',
+            '--generate' => 'product',
+            '--ui' => 'bootstrap',
+            '--extends' => 'layouts.app',
+            '--verb' => ['index', 'show', 'create', 'delete', 'edit'],
+        ]);
+
+        $this->assertViewExists('product/index.blade.php');
+        $this->assertViewExists('product/show.blade.php');
+        $this->assertViewExists('product/create.blade.php');
+        $this->assertViewExists('product/delete.blade.php');
+        $this->assertViewExists('product/edit.blade.php');
+
+        $this->artisan('scrap:view', [
+            'name' => 'product',
+            '--resource' => true,
+            '--force' => true,
+        ]);
+
+        $this->assertViewNotExists('product/index.blade.php');
+        $this->assertViewNotExists('product/show.blade.php');
+        $this->assertViewNotExists('product/create.blade.php');
+        $this->assertViewNotExists('product/delete.blade.php');
+        $this->assertViewNotExists('product/edit.blade.php');
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -34,7 +34,7 @@ class ConfigTest extends TestCase
         $config = (new Config)->setName('products')->setResource(true);
 
         $this->assertTrue($config->isResource());
-        $this->assertCount(4, $config->getVerbs());
+        $this->assertCount(5, $config->getVerbs());
     }
 
     /** @test */
@@ -42,8 +42,8 @@ class ConfigTest extends TestCase
     {
         $config = (new Config)->setName('index');
 
-        $config->setResource(true)->setVerbs('index', 'create', 'edit');
+        $config->setResource(true)->setVerbs('index', 'create', 'edit', 'delete');
 
-        $this->assertEquals(['index', 'create', 'edit'], $config->getVerbs());
+        $this->assertEquals(['index', 'create', 'edit', 'delete'], $config->getVerbs());
     }
 }


### PR DESCRIPTION
Adds the ability to generate CRUD views based on a model using bootstrap. This is quite useful when working on the backend and not having the frontend ready.

There are 2 ways to do it:

1. By specifying resource which means that index, create, delete, edit and show views will be generated
2. By specifying the verbs so that only part of them will be created

```bash
# Create a resource called 'products' with generated views using bootstrap ui extending layout.php
$ php artisan make:view products --resource --generate product --ui bootstrap --extends layout.php

# Create and generate edit and index views based on Product model using bootstrap ui extending layout.php
$ php artisan make:view products --verb=edit --verb=index --generate product --ui bootstrap --extends layout.php
```

Note that the **--generate** parameter was added and it takes a model name as value (so you'll need to have the App\Models\Product model created)

I've also added unit tests for this in the **tests/CRUDTest.php** file